### PR TITLE
Refactoring of "core" strings in classes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,18 +5,18 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.nebulamc</groupId>
-    <artifactId>Core</artifactId>
+    <artifactId>TownyCore</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Core</name>
+    <name>TownyCore</name>
 
     <description>The Main Core Plugin for Nebula Towny</description>
     <properties>
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <url>https://nebulamc.io/plugins/core</url>
+    <url>https://nebulamc.io/plugins/TownyCore</url>
 
     <build>
         <plugins>

--- a/src/main/java/io/nebulamc/core/Core.java
+++ b/src/main/java/io/nebulamc/core/Core.java
@@ -19,7 +19,7 @@ public final class Core extends JavaPlugin {
     @Override
     public void onEnable() {
         instance = this;
-        log.info("§e======= §5Nebula Core §e=======");
+        log.info("§e======= §5Nebula TownyCore §e=======");
         //Register EventListeners
         getServer().getPluginManager().registerEvents(new EventListener(), this);
 

--- a/src/main/java/io/nebulamc/core/PermissionNodes.java
+++ b/src/main/java/io/nebulamc/core/PermissionNodes.java
@@ -2,7 +2,7 @@ package io.nebulamc.core;
 
 public class PermissionNodes {
 
-    public static String baseCommand = "nebula.core";
-    public static String rtpCommand = "nebula.core.rtp";
+    public final String baseCommand = "nebula.townycore";
+    public final String rtpCommand = "nebula.townycore.rtp";
 
 }


### PR DESCRIPTION
Simple commit to change "core" to "TownyCore".

Inconsistent branding of "core" related to a global Nebula plugin hierarchy, Avoids confusion as to what "core" means across the network.